### PR TITLE
Make while/until non- mcl/lispworks specific

### DIFF
--- a/dm-source/lib-core/basicmacros.lsp
+++ b/dm-source/lib-core/basicmacros.lsp
@@ -42,7 +42,6 @@
     ,@body ))
 |#
 
-#+(or :mcl :lispworks)
 (defmacro while (test &rest body)
  `(loop while ,test do ,@body) )
 
@@ -54,8 +53,6 @@
     ,@body ))
 |#
 
-
-#+(or :mcl :lispworks)
 (defmacro until (test &rest body)
  `(loop until ,test do ,@body) )
 


### PR DESCRIPTION
Macros `while` and `until` are currently specific to mcl/lispworks
but are needed for all environments.
